### PR TITLE
Prevent Composer 1.x from trying (and failing) to install latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,20 @@
     "description": "Utility for downloading Chrome Driver binary for current os/platform",
     "require": {
         "php": ">=7.2.9",
-        "composer-plugin-api": "^1.0 | ^2.0",
+        "composer-plugin-api": "^2.0",
         "bolt/webdriver-binary-downloader": "^2.3.2"
     },
     "require-dev": {
-        "composer/composer": "^1.0 | ^2.0",
+        "composer/composer": "^2.0",
         "vaimo/composer-changelogs": "^0.15.4",
         "squizlabs/php_codesniffer": "^2.9.2",
         "phpcompatibility/php-compatibility": "^9.1.1",
         "phpmd/phpmd": "^2.6.0",
         "phpunit/phpunit": "^4.8.36",
         "sebastian/phpcpd": "^1.4.3"
+    },
+    "conflict": {
+        "composer-plugin-api": "^1.0"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
tl;dr: This package causes a PHP fatal error if installed (`composer require`'d) with Composer 1.x. This PR prevents Composer 1.x from trying, i.e., from identifying it as a match. It does not fix pre-existing problems--of which there are a good number--but it fixes the issue in question without making the others worse.

Details: Installing (`composer require`-ing) this package with Composer 2.x succeeds:

```bash
$ composer --version
Composer version 2.0.7 2020-11-13 17:31:06
$ composer init -n --name=test/example
$ composer require bolt/binary-chromedriver
Using version ^5.1 for bolt/binary-chromedriver
./composer.json has been updated
Running composer update bolt/binary-chromedriver
Loading composer repositories with package information
Updating dependencies
Lock file operations: 25 installs, 0 updates, 0 removals
  - ...
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 25 installs, 0 updates, 0 removals
  - ...
Generating autoload files
Installing ChromeDriver (v87.0.4280.20)
Extracting archive
Done
```

But with Composer 1.x it causes a PHP fatal error:

```bash
$ composer --version
Composer version 1.10.13 2020-09-09 11:46:34
$ composer init -n --name=test/example
$ composer require bolt/binary-chromedriver
Using version ^5.1 for bolt/binary-chromedriver
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 25 installs, 0 updates, 0 removals
 - ...
Writing lock file
Generating autoload files
Installing ChromeDriver (v87.0.4280.20)

Fatal error: Uncaught Error: Call to undefined method Composer\Composer::getLoop() in vendor/bolt/webdriver-binary-downloader/src/Managers/DownloadManager.php:141
Stack trace:
#0 vendor/bolt/webdriver-binary-downloader/src/Installer.php(102): Vaimo\WebDriverBinaryDownloader\Managers\DownloadManager->downloadRelease(Array, 5)
#1 vendor/bolt/binary-chromedriver/src/Plugin.php(48): Vaimo\WebDriverBinaryDownloader\Installer->executeWithConfig(Object(Vaimo\ChromeDriver\Plugin\Config))
#2 [internal function]: Vaimo\ChromeDriver\Plugin->installDriver(Object(Composer\Script\Event))
#3 composer/src/Composer/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Composer\Script\Event))
#4 composer/src/Composer/EventDispatcher/EventDispatcher.php(96): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Scri in vendor/bolt/webdriver-binary-downloader/src/Managers/DownloadManager.php on line 141
```

This PR causes Composer 1.x to not _try_ to install it. (It emits a misleading error message, but that's Composer's fault, not ours.)

```bash
$ composer --version
Composer version 1.10.13 2020-09-09 11:46:34
$ composer init -n --name=test/example
$ composer config repositories.local ../binary-chromedriver
$ composer config minimum-stability dev
$ composer config repositories.packagist false
$ composer require bolt/binary-chromedriver

  [InvalidArgumentException]
  Package bolt/binary-chromedriver at version  has a PHP requirement incompatible with your PHP version (7.3.11)
```

Composer 2.x still installs it successfully:

```bash
$ composer --version
Composer version 2.0.7 2020-11-13 17:31:06
$ composer init -n --name=test/example
$ composer config repositories.local ../binary-chromedriver
$ composer config minimum-stability dev
$ composer require bolt/binary-chromedriver
$ Using version dev-master for bolt/binary-chromedriver
./composer.json has been updated
Running composer update bolt/binary-chromedriver
Loading composer repositories with package information
Updating dependencies
Lock file operations: 25 installs, 0 updates, 0 removals
  - ...
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 25 installs, 0 updates, 0 removals
  - ...
Generating autoload files
Installing ChromeDriver (v87.0.4280.20)
Extracting archive
Done
```

This PR does not update the Composer lock file, which already is not up to date with the current state of the `composer.json` and in fact cannot be updated to match due to dev dependency conflicts. This and other pre-existing problems don't affect production use of the library, and fixing them would require coordinated changes with the related packages, e.g., `vaimo/composer-changelogs`.

Local testing as documented above indicates that this PR can be merged safely, without causing regression. It may be necessary to delete any previous tags on Packagist that incorrectly declare compatibility with both Composer 1.x and 2.x so that *they* aren't selected as matches by Composer 1.x. I haven't tested or investigated that question.